### PR TITLE
Add Supabase auth signup/login flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,39 @@
-// App.jsx
+import { useEffect, useState } from 'react'
 import WeekGames from './pages/WeekGames'
+import Auth from './pages/Auth'
+import { supabase } from './lib/supabaseClient'
 
 function App() {
+  const [user, setUser] = useState(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) setUser(user)
+    })
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null)
+    })
+    return () => {
+      listener.subscription.unsubscribe()
+    }
+  }, [])
+
+  const handleSignOut = async () => {
+    await supabase.auth.signOut()
+    setUser(null)
+  }
+
   return (
     <div className="App">
       <h1>College Football Pick'em</h1>
-      <WeekGames week={1} />
+      {user ? (
+        <>
+          <button onClick={handleSignOut}>Sign Out</button>
+          <WeekGames week={1} user={user} />
+        </>
+      ) : (
+        <Auth onAuth={setUser} />
+      )}
     </div>
   )
 }

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,3 +1,4 @@
+import { createClient } from "@supabase/supabase-js"
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)

--- a/src/pages/Auth.jsx
+++ b/src/pages/Auth.jsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { supabase } from '../lib/supabaseClient'
+
+function Auth({ onAuth }) {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [username, setUsername] = useState('')
+  const [error, setError] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [isSignUp, setIsSignUp] = useState(false)
+
+  const ensureUserRow = async (user) => {
+    const { data } = await supabase.from('users').select('id').eq('id', user.id).single()
+    if (!data) {
+      await supabase.from('users').insert({ id: user.id, email: user.email, username })
+    }
+  }
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setLoading(true)
+    setError(null)
+    if (isSignUp) {
+      const { data, error: signUpError } = await supabase.auth.signUp({ email, password })
+      if (signUpError) {
+        setError(signUpError.message)
+      } else {
+        const user = data.user
+        if (user) {
+          await supabase.from('users').insert({ id: user.id, email, username })
+          onAuth(user)
+        }
+      }
+    } else {
+      const { data, error: signInError } = await supabase.auth.signInWithPassword({ email, password })
+      if (signInError) {
+        setError(signInError.message)
+      } else {
+        const user = data.user
+        if (user) {
+          await ensureUserRow(user)
+          onAuth(user)
+        }
+      }
+    }
+    setLoading(false)
+  }
+
+  return (
+    <div>
+      <h2>{isSignUp ? 'Sign Up' : 'Log In'}</h2>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={handleSubmit}>
+        <input
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        {isSignUp && (
+          <input
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+        )}
+        <button type="submit" disabled={loading}>
+          {isSignUp ? 'Sign Up' : 'Log In'}
+        </button>
+      </form>
+      <button type="button" onClick={() => setIsSignUp(!isSignUp)}>
+        {isSignUp ? 'Have an account? Log In' : 'Need an account? Sign Up'}
+      </button>
+    </div>
+  )
+}
+
+export default Auth

--- a/src/pages/WeekGames.jsx
+++ b/src/pages/WeekGames.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
 
-function WeekGames({ week = 1 }) {
+function WeekGames({ week = 1, user }) {
   const [games, setGames] = useState([])
   const [picks, setPicks] = useState({})
   const [submitting, setSubmitting] = useState(false)
@@ -32,8 +32,9 @@ function WeekGames({ week = 1 }) {
   }
 
   const handleSubmit = async () => {
+    if (!user) return
     setSubmitting(true)
-    const userId = 'demo-user' // 🔁 Replace with `supabase.auth.getUser()` later
+    const userId = user.id
 
     const inserts = Object.entries(picks).map(([gameId, selected_team]) => ({
       user_id: userId,


### PR DESCRIPTION
## Summary
- add Supabase client import
- implement `Auth` component for signup/login
- wire up auth in `App.jsx`
- send user id to `WeekGames` when submitting picks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687bd917d0e4832d898966303e93f472