### PR TITLE
Add WeekGames component for week 1 schedule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cfb-pickem",
+  "name": "Core10-Pickem",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cfb-pickem",
+      "name": "Core10-Pickem",
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.3",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,7 @@ function App() {
       {user ? (
         <>
           <button onClick={handleSignOut}>Sign Out</button>
-          <WeekGames week={1} user={user} />
+          <WeekGames />
         </>
       ) : (
         <Auth onAuth={setUser} />

--- a/src/pages/WeekGames.jsx
+++ b/src/pages/WeekGames.jsx
@@ -1,85 +1,38 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '../lib/supabaseClient'
 
-function WeekGames({ week = 1, user }) {
+export default function WeekGames() {
   const [games, setGames] = useState([])
-  const [picks, setPicks] = useState({})
-  const [submitting, setSubmitting] = useState(false)
 
-    useEffect(() => {
+  useEffect(() => {
     const fetchGames = async () => {
-        const { data, error } = await supabase
+      const { data, error } = await supabase
         .from('games')
-        .select('*')
-        .eq('week', week)
+        .select('id, kickoff, home_team, away_team')
+        .eq('week', 1)
+        .order('kickoff', { ascending: true })
 
-        console.log('Games data:', data)
-        console.log('Supabase error:', error)
-
-        if (error) console.error('Error fetching games:', error)
-        else setGames(data)
+      if (error) {
+        console.error('Error fetching games:', error)
+      } else {
+        setGames(data)
+      }
     }
 
     fetchGames()
-    }, [week])
-
-
-  const handlePickChange = (gameId, team) => {
-    setPicks(prev => ({
-      ...prev,
-      [gameId]: team
-    }))
-  }
-
-  const handleSubmit = async () => {
-    if (!user) return
-    setSubmitting(true)
-    const userId = user.id
-
-    const inserts = Object.entries(picks).map(([gameId, selected_team]) => ({
-      user_id: userId,
-      game_id: gameId,
-      selected_team,
-      week
-    }))
-
-    const { error } = await supabase.from('picks').insert(inserts)
-
-    if (error) console.error('Error submitting picks:', error)
-    else alert('Picks submitted!')
-
-    setSubmitting(false)
-  }
+  }, [])
 
   return (
     <div>
-      <h2>Week {week} Picks</h2>
-      <form onSubmit={(e) => { e.preventDefault(); handleSubmit() }}>
+      <h2>Week 1 Games</h2>
+      <ul>
         {games.map(game => (
-          <div key={game.id} style={{ marginBottom: '1rem' }}>
-            <strong>{game.away_team}</strong> @ <strong>{game.home_team}</strong><br />
-            <label>
-              <input
-                type="radio"
-                name={`pick-${game.id}`}
-                value={game.away_team}
-                onChange={() => handlePickChange(game.id, game.away_team)}
-              /> {game.away_team}
-            </label>
-            <label style={{ marginLeft: '1rem' }}>
-              <input
-                type="radio"
-                name={`pick-${game.id}`}
-                value={game.home_team}
-                onChange={() => handlePickChange(game.id, game.home_team)}
-              /> {game.home_team}
-            </label>
-          </div>
+          <li key={game.id}>
+            <span>{new Date(game.kickoff).toLocaleString()}</span>: 
+            <strong>{game.away_team}</strong> @ <strong>{game.home_team}</strong>
+          </li>
         ))}
-        <button type="submit" disabled={submitting}>Submit Picks</button>
-      </form>
+      </ul>
     </div>
   )
 }
-
-export default WeekGames


### PR DESCRIPTION
## Summary
- simplify WeekGames page to just show games for week 1
- update App to use new WeekGames component
- sync package-lock metadata with package.json

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687be2485dac832d8abd5daf98fd7e45