### PR TITLE
Add initial pick'em app pages

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../lib/supabaseClient'
+
+export default function Home() {
+  const [leaderboard, setLeaderboard] = useState([])
+  const [weekSummary, setWeekSummary] = useState([])
+  const currentWeek = 1
+
+  useEffect(() => {
+    const fetchLeaderboard = async () => {
+      const { data, error } = await supabase
+        .from('scores')
+        .select('user_id, week, points, users(username)')
+
+      if (!error) {
+        const totals = {}
+        data.forEach((row) => {
+          const key = row.user_id
+          totals[key] = totals[key] || { user_id: key, username: row.users?.username, points: 0 }
+          totals[key].points += row.points
+        })
+        setLeaderboard(Object.values(totals).sort((a, b) => b.points - a.points))
+      }
+    }
+
+    const fetchWeekSummary = async () => {
+      const { data: games } = await supabase
+        .from('games')
+        .select('*')
+        .eq('week', currentWeek)
+        .order('kickoff')
+
+      const { data: picks } = await supabase
+        .from('picks')
+        .select('game_id, selected_team, users(username)')
+        .eq('week', currentWeek)
+
+      const summary = (games || []).map((game) => {
+        const gamePicks = (picks || []).filter((p) => p.game_id === game.id)
+        return {
+          ...game,
+          picks: gamePicks,
+        }
+      })
+      setWeekSummary(summary)
+    }
+
+    fetchLeaderboard()
+    fetchWeekSummary()
+  }, [])
+
+  return (
+    <div>
+      <h2>Leaderboard</h2>
+      <ul>
+        {leaderboard.map((row) => (
+          <li key={row.user_id}>
+            {row.username || row.user_id}: {row.points} pts
+          </li>
+        ))}
+      </ul>
+
+      <h2>Week {currentWeek} Results</h2>
+      {weekSummary.map((game) => (
+        <div key={game.id} style={{ marginBottom: '1rem' }}>
+          <div>
+            <strong>{game.away_team}</strong> @ <strong>{game.home_team}</strong>
+            {' '} - Winner: {game.winner || 'TBD'}
+          </div>
+          <ul>
+            {game.picks.map((p, i) => (
+              <li key={i}>
+                {p.users?.username || p.user_id}: {p.selected_team}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/SubmitYearlyPicks.jsx
+++ b/src/pages/SubmitYearlyPicks.jsx
@@ -1,0 +1,62 @@
+import { useState, useEffect } from 'react'
+import { supabase } from '../lib/supabaseClient'
+
+export default function SubmitYearlyPicks() {
+  const [champion, setChampion] = useState('')
+  const [conferenceWinner, setConferenceWinner] = useState('')
+  const [user, setUser] = useState(null)
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => setUser(user))
+  }, [])
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    if (!user) {
+      setMessage('Please log in to submit picks')
+      return
+    }
+
+    const entries = [
+      { prediction_type: 'champion', prediction_value: champion },
+      { prediction_type: 'conference_winner', prediction_value: conferenceWinner },
+    ]
+
+    for (const entry of entries) {
+      if (!entry.prediction_value) continue
+      await supabase.from('yearly_picks').upsert({
+        user_id: user.id,
+        prediction_type: entry.prediction_type,
+        prediction_value: entry.prediction_value,
+      }, { onConflict: 'user_id,prediction_type' })
+    }
+
+    setMessage('Picks submitted!')
+  }
+
+  return (
+    <div>
+      <h2>Yearly Predictions</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>
+            National Champion:
+            <input value={champion} onChange={(e) => setChampion(e.target.value)} />
+          </label>
+        </div>
+        <div>
+          <label>
+            Conference Winner:
+            <input
+              value={conferenceWinner}
+              onChange={(e) => setConferenceWinner(e.target.value)}
+            />
+          </label>
+        </div>
+        <button type="submit">Submit Picks</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  )
+}

--- a/src/pages/WeeklyPicks.jsx
+++ b/src/pages/WeeklyPicks.jsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import { supabase } from '../lib/supabaseClient'
+
+export default function WeeklyPicks() {
+  const [games, setGames] = useState([])
+  const [picks, setPicks] = useState([])
+  const [user, setUser] = useState(null)
+  const currentWeek = 1
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => setUser(user))
+
+    const fetchGames = async () => {
+      const { data } = await supabase
+        .from('games')
+        .select('*')
+        .eq('week', currentWeek)
+        .order('kickoff')
+      setGames(data || [])
+    }
+
+    const fetchPicks = async () => {
+      const { data } = await supabase
+        .from('picks')
+        .select('*')
+        .eq('week', currentWeek)
+      setPicks(data || [])
+    }
+
+    fetchGames()
+    fetchPicks()
+  }, [])
+
+  const handlePick = async (gameId, team) => {
+    if (!user) return
+    const existing = picks.find((p) => p.user_id === user.id && p.game_id === gameId)
+    if (existing) {
+      await supabase
+        .from('picks')
+        .update({ selected_team: team })
+        .eq('id', existing.id)
+    } else {
+      await supabase.from('picks').insert({
+        user_id: user.id,
+        game_id: gameId,
+        selected_team: team,
+        week: currentWeek,
+      })
+    }
+    const { data } = await supabase
+      .from('picks')
+      .select('*')
+      .eq('week', currentWeek)
+    setPicks(data || [])
+  }
+
+  const renderGame = (game) => {
+    const kickoff = new Date(game.kickoff)
+    const kickoffPassed = kickoff <= new Date()
+    const userPick = user && picks.find((p) => p.user_id === user.id && p.game_id === game.id)
+    const gamePicks = picks.filter((p) => p.game_id === game.id)
+
+    if (kickoffPassed) {
+      return (
+        <div key={game.id} style={{ marginBottom: '1rem' }}>
+          <div>
+            <strong>{game.away_team}</strong> @ <strong>{game.home_team}</strong> - Winner: {game.winner || 'TBD'}
+          </div>
+          <ul>
+            {gamePicks.map((p) => (
+              <li key={p.id}>
+                {p.user_id}: {p.selected_team}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )
+    }
+
+    return (
+      <div key={game.id} style={{ marginBottom: '1rem' }}>
+        <div>
+          <strong>{game.away_team}</strong> @ <strong>{game.home_team}</strong>
+        </div>
+        {user ? (
+          <div>
+            <button onClick={() => handlePick(game.id, game.away_team)} disabled={userPick?.selected_team === game.away_team}>
+              {game.away_team}
+            </button>
+            <button onClick={() => handlePick(game.id, game.home_team)} disabled={userPick?.selected_team === game.home_team}>
+              {game.home_team}
+            </button>
+            {userPick && <span> Picked: {userPick.selected_team}</span>}
+          </div>
+        ) : (
+          <div>Please log in to make picks</div>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h2>Week {currentWeek} Picks</h2>
+      {games.map(renderGame)}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Home page that fetches leaderboard scores and week results from Supabase
- add WeeklyPicks page with pick submission before kickoff and result display after
- add SubmitYearlyPicks page for posting yearly predictions

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687be5171b64832dba1565ae5b00e2e3